### PR TITLE
Rt/restructure

### DIFF
--- a/editor.css
+++ b/editor.css
@@ -1,0 +1,11 @@
+.debug {
+    padding-left: 2em;
+    border: 1px solid #eee;
+}
+
+.debug blockquote {
+    border: solid #eee 1px;
+    margin-left: 0;
+    padding-left: 1em;
+}
+

--- a/src/content.elm
+++ b/src/content.elm
@@ -18,7 +18,8 @@ module Content exposing
     (Content, init, currentParagraph, setCurrentParagraph,
     selectNextParagraph, selectPreviousParagraph,
     hasNextParagraph, hasPreviousParagraph,
-    updateCurrentParagraph)
+    updateCurrentParagraph, mergeWithPreviousParagraph,
+    insertParagraph, toList)
 
 {-|
 @docs Content
@@ -26,6 +27,9 @@ module Content exposing
 @docs selectNextParagraph, selectPreviousParagraph
 @docs hasNextParagraph, hasPreviousParagraph
 @docs updateCurrentParagraph
+@docs mergeWithPreviousParagraph
+@docs insertParagraph
+@docs toList
 -}
 
 
@@ -52,7 +56,7 @@ currentParagraph = ZipList.current
 
 {-| Set the current paragraph
 -}
-setCurrentParagraph : Paragraph -> Content -> Paragraph
+setCurrentParagraph : Paragraph -> Content -> Content
 setCurrentParagraph = ZipList.setCurrent
 
 
@@ -88,3 +92,40 @@ updateCurrentParagraph fn content =
     |> currentParagraph
     |> fn
     |> flip (setCurrent) content
+
+
+{-| Merge the current and previous paragraphs
+-}
+mergeWithPreviousParagraph : Content -> Content
+mergeWithPreviousParagraph content =
+  let
+      p1 : Paragraph
+      p1 =
+        content
+          |> selectPreviousParagraph
+          |> currentParagraph
+
+      p2 : Paragraph
+      p2 =
+        content
+          |> currentParagraph
+
+      merged : Paragraph
+      merged =
+        Paragraph.merge p1 p2
+  in
+      content
+        |> ZipList.removeCurrentBack
+        |> setCurrentParagraph merged
+
+
+{-| Insert a new paragraph after the current paragraph and select it
+-}
+insertParagraph : List Style -> Content -> Content
+insertParagraph = ZipList.insertAfter << Paragraph.fromList
+
+
+{-| Make a List of Paragraphs from a Content
+-}
+toList : Content -> List Paragraph
+toList = ZipList.toList

--- a/src/content.elm
+++ b/src/content.elm
@@ -1,0 +1,90 @@
+{-
+Copyright (C) 2017  Riley Trautman
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-}
+module Content exposing
+    (Content, init, currentParagraph, setCurrentParagraph,
+    selectNextParagraph, selectPreviousParagraph,
+    hasNextParagraph, hasPreviousParagraph,
+    updateCurrentParagraph)
+
+{-|
+@docs Content
+@docs init, currentParagraph, setCurrentParagraph,
+@docs selectNextParagraph, selectPreviousParagraph
+@docs hasNextParagraph, hasPreviousParagraph
+@docs updateCurrentParagraph
+-}
+
+
+import Paragraph exposing (..)
+import ZipList exposing (..)
+
+
+{-| Content is an alias for List Paragraph
+-}
+type alias Content = ZipList Paragraph
+
+
+{-| init returns a new content with an empty paragraph inside
+-}
+init : Content
+init = ZipList.init Paragraph.empty
+
+
+{-| Get the current paragraph
+-}
+currentParagraph : Content -> Paragraph
+currentParagraph = ZipList.current
+
+
+{-| Set the current paragraph
+-}
+setCurrentParagraph : Paragraph -> Content -> Paragraph
+setCurrentParagraph = ZipList.setCurrent
+
+
+{-| Gets the next paragraph
+-}
+selectNextParagraph : Content -> Content
+selectNextParagraph = ZipList.shiftForward
+
+
+{-| Gets the previous paragraph
+-}
+selectPreviousParagraph : Content -> Content
+selectPreviousParagraph = ZipList.shiftBack
+
+
+{-| Checks if next paragraph exists
+-}
+hasNextParagraph : Content -> Bool
+hasNextParagraph = ZipList.canShiftForward
+
+
+{-| Checks if previous paragraph exists
+-}
+hasPreviousParagraph : Content -> Bool
+hasPreviousParagraph = ZipList.canShiftBack
+
+
+{-| Applies update function to current paragraph
+-}
+updateCurrentParagraph : (Paragraph -> Paragraph) -> Content -> Content
+updateCurrentParagraph fn content =
+  content
+    |> currentParagraph
+    |> fn
+    |> flip (setCurrent) content

--- a/src/content.elm
+++ b/src/content.elm
@@ -19,7 +19,7 @@ module Content exposing
     selectNextParagraph, selectPreviousParagraph,
     hasNextParagraph, hasPreviousParagraph,
     updateCurrentParagraph, mergeWithPreviousParagraph,
-    insertParagraph, toList)
+    insertParagraph, toList, serializeToString)
 
 {-|
 @docs Content
@@ -29,7 +29,7 @@ module Content exposing
 @docs updateCurrentParagraph
 @docs mergeWithPreviousParagraph
 @docs insertParagraph
-@docs toList
+@docs toList, serializeToString
 -}
 
 
@@ -123,10 +123,19 @@ mergeWithPreviousParagraph content =
 {-| Insert a new paragraph after the current paragraph and select it
 -}
 insertParagraph : List Style -> Content -> Content
-insertParagraph = ZipList.insertAfter << Paragraph.fromList
+insertParagraph style_list content =
+  content
+    |> updateCurrentParagraph Paragraph.removeIfMaybe
+    |> ZipList.insertAfter (Paragraph.fromList style_list)
 
 
 {-| Make a List of Paragraphs from a Content
 -}
 toList : Content -> List Paragraph
 toList = ZipList.toList
+
+
+{-| Serialize the current Content to a string
+-}
+serializeToString : (Paragraph -> String) -> Content -> String
+serializeToString = ZipList.serializeToString

--- a/src/content.elm
+++ b/src/content.elm
@@ -35,6 +35,7 @@ module Content exposing
 
 import Paragraph exposing (..)
 import ZipList exposing (..)
+import Styles exposing (Style)
 
 
 {-| Content is an alias for List Paragraph

--- a/src/keys.elm
+++ b/src/keys.elm
@@ -1,5 +1,5 @@
 {-
-Copyright (C) 2016  Riley Trautman
+Copyright (C) 2017  Riley Trautman
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/keys.elm
+++ b/src/keys.elm
@@ -60,6 +60,8 @@ type alias Modifiers =
   }
 
 
+{-| Initialize modifiers with sane defaults
+-}
 defaultModifiers =
   { ctrl = False
   , alt = False

--- a/src/keys.elm
+++ b/src/keys.elm
@@ -15,12 +15,12 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -}
 module Keys exposing
-    (KeyCmd(..), Modifiers, handleCode)
+    (KeyCmd(..), Modifiers, handleCode, defaultModifiers)
 
 {-|
 @docs KeyCmd
 
-@docs handleCode
+@docs handleCode defaultModifiers
 -}
 
 -- Imports
@@ -57,6 +57,13 @@ type alias Modifiers =
   { ctrl: Bool
   , alt: Bool
   , shift: Bool
+  }
+
+
+defaultModifiers =
+  { ctrl = False
+  , alt = False
+  , shift = False
   }
 
 

--- a/src/list_tools.elm
+++ b/src/list_tools.elm
@@ -1,0 +1,111 @@
+{-
+Copyright (C) 2017  Riley Trautman
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-}
+module ListTools exposing
+    (last, lastWithDefault, headWithDefault, dropLast, dropHead)
+
+{-|
+@docs last, lastWithDefault, headWithDefault, dropLast, dropHead
+-}
+
+
+import Util exposing (fromMaybeWithDefault)
+
+
+{-| last gets the last item in the list
+
+examples:
+
+  > last [1, 2, 3, 4]
+  Just 4
+
+  > last []
+  Nothing
+
+-}
+last : List a -> Maybe a
+last = List.head << List.reverse
+
+
+{-| lastWithDefault gets the last item in the list
+
+if the list is empty, we return the default value
+
+examples:
+
+  > lastWithDefault 0 [1, 2, 3, 4]
+  4
+
+  > lastWithDefault 0 []
+  0
+
+-}
+lastWithDefault : a -> List a -> a
+lastWithDefault default list =
+  list
+    |> last
+    |> Util.fromMaybeWithDefault identity default
+
+
+{-| headWithDefault gets the first item in the list
+
+if the list is empty, we return the default value
+
+examples:
+
+  > headWithDefault 0 [1, 2, 3, 4]
+  1
+
+  > headWithDefault 0 []
+  0
+
+-}
+headWithDefault : a -> List a -> a
+headWithDefault default list =
+  list
+    |> List.head
+    |> Util.fromMaybeWithDefault identity default
+
+
+{-| dropLast removes the last item from the list
+
+examples:
+
+  > dropLast [1, 2, 3, 4]
+  [1, 2, 3]
+
+  > dropLast []
+  []
+
+-}
+dropLast : List a -> List a
+dropLast list =
+  List.take (List.length list - 1) list
+
+
+{-| dropHead removes the first item from the list
+
+examples:
+
+  > dropHead [1, 2, 3]
+  [2, 3]
+
+  > dropHead []
+  []
+
+-}
+dropHead : List a -> List a
+dropHead = drop 1

--- a/src/list_tools.elm
+++ b/src/list_tools.elm
@@ -108,4 +108,4 @@ examples:
 
 -}
 dropHead : List a -> List a
-dropHead = drop 1
+dropHead = List.drop 1

--- a/src/main.elm
+++ b/src/main.elm
@@ -181,10 +181,6 @@ keydown model key_code =
           (model, Cmd.none)
 
 
-currentParagraph : ContentNavigation -> Paragraph
-currentParagraph cn = Content.currentParagraph cn.content
-
-
 shiftLeft : (String -> String -> (String, String))
 shiftLeft previous next =
   (String.dropRight 1 previous, (String.right 1 previous) ++ next)

--- a/src/maybe_zip_list.elm
+++ b/src/maybe_zip_list.elm
@@ -19,7 +19,7 @@ module MaybeZipList exposing
     insertBefore, insertAfter, removeCurrentForward, removeCurrentBack,
     toList, fromList, current, setCurrent, empty, isEmpty,
     canShiftBack, canShiftForward, merge, next, previous,
-    deleteNext, deletePrevious)
+    deleteNext, deletePrevious, serializeToString)
 
 {-|
 @docs MaybeZipList
@@ -32,6 +32,7 @@ module MaybeZipList exposing
 @docs canShiftBack, canShiftForward
 @docs merge
 @docs next, previous, deleteNext, deletePrevious
+@docs serializeToString
 -}
 
 {-| MaybeZipLists are useful for ensuring a list can only ever
@@ -611,3 +612,31 @@ deletePrevious (MaybeZipList {current, next}) =
     , current = current
     , next = next
     }
+
+
+{-| Serialize the current item to String
+-}
+serializeToString : (a -> String) -> MaybeZipList a -> String
+serializeToString fn (MaybeZipList {previous, current, next}) =
+  let
+      string_previous : String
+      string_previous =
+        "previous: [" ++ (String.join ", " (List.map fn previous)) ++ "]"
+
+      string_current : String
+      string_current =
+        case current of
+          Just c ->
+            "current: (Just " ++ (fn c) ++ ")"
+
+          Nothing ->
+            "current: Nothing"
+
+      string_next : String
+      string_next =
+        "next: [" ++ (String.join ", " (List.map fn next)) ++ "]"
+  in
+      "MaybeZipList {"
+        ++ string_previous ++ ", "
+        ++ string_current ++ ", "
+        ++ string_next ++ "}"

--- a/src/maybe_zip_list.elm
+++ b/src/maybe_zip_list.elm
@@ -18,7 +18,8 @@ module MaybeZipList exposing
     (MaybeZipList, shiftBack, shiftForward, toStart, toEnd,
     insertBefore, insertAfter, removeCurrentForward, removeCurrentBack
     toList, fromList, current, setCurrent, empty, isEmpty,
-    canShiftBack, canShiftForward)
+    canShiftBack, canShiftForward, merge, next, previous,
+    deleteNext, deletePrevious)
 
 {-|
 @docs MaybeZipList
@@ -29,6 +30,8 @@ module MaybeZipList exposing
 @docs current, setCurrent
 @docs empty, isEmpty
 @docs canShiftBack, canShiftForward
+@docs merge
+@docs next, previous, deleteNext, deletePrevious
 -}
 
 {-| MaybeZipLists are useful for ensuring a list can only ever
@@ -561,3 +564,50 @@ canShiftBack (MaybeZipList {previous}) =
 canShiftForward : MaybeZipList a -> Bool
 canShiftForward (MaybeZipList {next}) =
   not (List.isEmpty next)
+
+
+{-| Merges the current MaybeZipList with another
+
+This merge preserves the current selection of the first MaybeZipList
+-}
+merge : MaybeZipList a -> MaybeZipList a -> MaybeZipList a
+merge (MaybeZipList {previous, current, next}) two =
+  MaybeZipList
+    { previous = previous
+    , current = current
+    , next = next ++ (toList two)
+    }
+
+
+{-| Get the next items after the current
+-}
+next : MaybeZipList a -> List a
+next (MaybeZipList {next}) = next
+
+
+{-| Get the previous items before the current
+-}
+previous : MaybeZipList a -> List a
+previous (MaybeZipList {previous}) = List.reverse previous
+
+
+{-| Remove the items after current
+-}
+deleteNext : MaybeZipList a -> MaybeZipList a
+deleteNext (MaybeZipList {previous, current}) =
+  MaybeZipList
+    { previous = previous
+    , current = current
+    , next = []
+    }
+
+
+{-| Remove the items before current
+-}
+deletePrevious : MaybeZipList a -> MaybeZipList a
+deletePrevious (MaybeZipList {current, next}) =
+  MaybeZipList
+    { previous = []
+    , current = current
+    , next = next
+    }

--- a/src/maybe_zip_list.elm
+++ b/src/maybe_zip_list.elm
@@ -1,0 +1,563 @@
+{-
+Copyright (C) 2017  Riley Trautman
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-}
+module MaybeZipList exposing
+    (MaybeZipList, shiftBack, shiftForward, toStart, toEnd,
+    insertBefore, insertAfter, removeCurrentForward, removeCurrentBack
+    toList, fromList, current, setCurrent, empty, isEmpty,
+    canShiftBack, canShiftForward)
+
+{-|
+@docs MaybeZipList
+@docs shiftForward, shiftBack, toStart, toEnd
+@docs insertBefore, insertAfter
+@docs removeCurrentForward, removeCurrentBack
+@docs toList, fromList
+@docs current, setCurrent
+@docs empty, isEmpty
+@docs canShiftBack, canShiftForward
+-}
+
+{-| MaybeZipLists are useful for ensuring a list can only ever
+have zero or one Nothing
+
+They also have a concept of a "current" element.
+The MaybeZipList's previous and next lists are treated as stacks.
+-}
+type MaybeZipList a =
+  MaybeZipList
+    { previous : List a
+    , current : Maybe a
+    , next : List a
+    }
+
+
+{- shiftBack cycles through the MaybeZipList towards the beginning
+
+examples:
+
+  > shiftBack (MaybeZipList {[3, 2, 1], Just 4, [5, 6, 7]})
+  MaybeZipList {[2, 1], Just 3, [4, 5, 6, 7]}
+
+  > shiftBack (MaybeZipList {[2, 1], Just 3, [4, 5, 6, 7]})
+  MaybeZipList {[1], Just 2, [3, 4, 5, 6, 7]}
+
+  > shiftBack (MaybeZipList {[1], Just 2, [3, 4, 5, 6, 7]})
+  MaybeZipList {[], Just 1, [2, 3, 4, 5, 6, 7]}
+
+  > shiftBack (MaybeZipList {[], Just 1, [2, 3, 4, 5, 6, 7]})
+  MaybeZipList {[], Just 1, [2, 3, 4, 5, 6, 7]}
+
+  > shiftBack (MaybeZipList {[3, 2, 1], Nothing, [5, 6, 7]})
+  MaybeZipList {[2, 1], Just 3, [5, 6, 7]}
+
+  > shiftBack (MaybeZipList {[], Nothing, [5, 6, 7]})
+  MaybeZipList {[], Nothing, [5, 6, 7]}
+
+-}
+shiftBack : MaybeZipList a -> MaybeZipList a
+shiftBack (MaybeZipList {previous, current, next}) =
+  let
+      new_next =
+        case current of
+          Just c ->
+            c::next
+
+          Nothing ->
+            next
+  in
+      case previous of
+        [] ->
+          MaybeZipList
+            { previous = []
+            , current = current
+            , next = next
+            }
+
+        [last] ->
+          MaybeZipList
+            { previous = []
+            , current = Just last
+            , next = new_next
+            }
+
+        first::rest ->
+          MaybeZipList
+            { previous = rest
+            , current = Just first
+            , next = new_next
+            }
+
+
+{- shiftForward cycles through the MaybeZipList towards the end
+
+examples:
+
+  > shiftForward (MaybeZipList {[3, 2, 1], Just 4, [5, 6, 7]})
+  MaybeZipList {[4, 3, 2, 1], Just 5, [6, 7]}
+
+  > shiftForward (MaybeZipList {[4, 3, 2, 1], Just 5, [6, 7]})
+  MaybeZipList {[5, 4, 3, 2, 1], Just 6, [7]}
+
+  > shiftForward (MaybeZipList {[5, 4, 3, 2, 1], Just 6, [7]})
+  MaybeZipList {[6, 5, 4, 3, 2, 1], Just 7, []}
+
+  > shiftForward (MaybeZipList {[6, 5, 4, 3, 2, 1], Just 7, []})
+  MaybeZipList {[6, 5, 4, 3, 2, 1], Just 7, []}
+
+  > shiftForward (MaybeZipList {[3, 2, 1], Nothing, [5, 6, 7]})
+  MaybeZipList {[3, 2, 1], Nothing, [6, 7]}
+
+  > shiftForward (MaybeZipList {[6, 5, 4, 3, 2, 1], Nothing, []})
+  MaybeZipList {[6, 5, 4, 3, 2, 1], Nothing, []}
+
+-}
+shiftForward : MaybeZipList a -> MaybeZipList a
+shiftForward (MaybeZipList {previous, current, next}) =
+  let
+      new_previous =
+        case current of
+          Just c ->
+            c::previous
+
+          Nothing ->
+            previous
+  in
+      case next of
+        [] ->
+          MaybeZipList
+            { previous = previous
+            , current = current
+            , next = []
+            }
+
+        [first] ->
+          MaybeZipList
+            { previous = new_previous
+            , current = Just first
+            , next = []
+            }
+
+        first::rest ->
+          MaybeZipList
+            { previous = new_previous
+            , current = Just first
+            , next = rest
+            }
+
+
+{-| toStart resets the MaybeZipList to the beginning
+
+examples:
+
+  toStart (MaybeZipList {[3, 2, 1], Just 4, [5, 6]})
+  MaybeZipList {[], Just 1, [2, 3, 4, 5, 6]}
+
+  toStart (MaybeZipList {[], Just 1, []})
+  MaybeZipList {[], Just 1, []}
+
+  toStart (MaybeZipList {[3, 2, 1], Nothing, [5, 6]})
+  MaybeZipList {[], Just 1, [2, 3, 5, 6]}
+
+  toStart (MaybeZipList {[], Nothing, []})
+  MaybeZipList {[], Nothing, []}
+
+-}
+toStart : MaybeZipList a -> MaybeZipList a
+toStart (MaybeZipList {previous, current, next}) =
+  let
+      new_next =
+        case current of
+          Just c ->
+            c::next
+
+          Nothing ->
+            next
+  in
+      case previous of
+        [] ->
+          MaybeZipList
+            { previous = previous
+            , current = current
+            , next = next
+            }
+
+        [first] ->
+          MaybeZipList
+            { previous = []
+            , current = Just first
+            , next = new_next
+            }
+
+        first::rest ->
+          toStart
+            (MaybeZipList
+            { previous = rest
+            , current = Just first
+            , next = new_next
+            })
+
+
+{-| toEnd resets the MaybeZipList to the beginning
+
+examples:
+
+  toEnd (MaybeZipList {[3, 2, 1], 4, [5, 6]})
+  MaybeZipList {[5, 4, 3, 2, 1], 6, []}
+
+  toEnd (MaybeZipList {[], 1, []})
+  MaybeZipList {[], 1, []}
+
+  toEnd (MaybeZipList {[3, 2, 1], Nothing, [5, 6]})
+  MaybeZipList {[5, 3, 2, 1], 6, []}
+
+  toEnd (MaybeZipList {[], Nothing, []})
+  MaybeZipList {[], Nothing, []}
+
+-}
+toEnd : MaybeZipList a -> MaybeZipList a
+toEnd (MaybeZipList {previous, current, next}) =
+  let
+      new_previous =
+        case current of
+          Just c ->
+            c::previous
+
+          Nothing ->
+            previous
+  in
+      case next of
+        [] ->
+          MaybeZipList
+            { previous = previous
+            , current = current
+            , next = next
+            }
+
+        [first] ->
+          MaybeZipList
+            { previous = new_previous
+            , current = Just first
+            , next = []
+            }
+
+        first::rest ->
+          toEnd
+            (MaybeZipList
+            { previous = new_previous
+            , current = Just first
+            , next = rest
+            })
+
+
+{-| insertBefore puts a new item in the MaybeZipList before the current item
+
+examples:
+
+  > insertBefore (Just 3) (MaybeZipList {[2, 1], Just 4, [5, 6]})
+  MaybeZipList {[2, 1], 3, [4, 5, 6]}
+
+  > insertBefore (Just 3) (MaybeZipList {[], Just 1, []})
+  MaybeZipList {[], Just 3, [1]}
+
+  > insertBefore Nothing (MaybeZipList {[], Just 3, []})
+  MaybeZipList {[], Nothing, [3]}
+
+  > insertBefore Nothing (MaybeZipList {[], Nothing, []})
+  MaybeZipList {[], Nothing, []}
+
+-}
+insertBefore : Maybe a -> MaybeZipList a -> MaybeZipList a
+insertBefore elem (MaybeZipList {previous, current, next}) =
+  let
+      new_next =
+        case current of
+          Just c ->
+            c::next
+
+          Nothing ->
+            next
+  in
+      MaybeZipList
+        { previous = previous
+        , current = elem
+        , next = new_next
+        }
+
+
+{-| insertAfter puts a new item in the MaybeZipList before the current item
+
+examples:
+
+  > insertAfter (Just 3) (MaybeZipList {[2, 1], Just 4, [5, 6]})
+  MaybeZipList {[4, 2, 1], 3, [5, 6]}
+
+  > insertAfter (Just 3) (MaybeZipList {[], Just 1, []})
+  MaybeZipList {[1], Just 3, []}
+
+  > insertAfter Nothing (MaybeZipList {[2, 1], Just 4, [5, 6]})
+  MaybeZipList {[4, 2, 1], Nothing, [5, 6]}
+
+  > insertAfter Nothing (MaybeZipList {[], Nothing, []})
+  MaybeZipList {[], Nothing, []}
+
+-}
+insertAfter : Maybe a -> MaybeZipList a -> MaybeZipList a
+insertAfter elem (MaybeZipList {previous, current, next}) =
+  let
+      new_previous =
+        case current of
+          Just c ->
+            c::previous
+
+          Nothing ->
+            previous
+  in
+      MaybeZipList
+        { previous = new_previous
+        , current = elem
+        , next = next
+        }
+
+
+{-| removeCurrentForward shifts the top of the next stack into current
+
+examples:
+
+  > removeCurrentForward (MaybeZipList {[3, 2, 1], 4, [5, 6, 7]})
+  MaybeZipList {[3, 2, 1], 5, [6, 7]}
+
+  > removeCurrentForward (MaybeZipList {[3, 2, 1], 5, [6, 7]})
+  MaybeZipList {[3, 2, 1], 6, [7]}
+
+  > removeCurrentForward (MaybeZipList {[3, 2, 1], 6, [7]})
+  MaybeZipList {[3, 2, 1], 7, []}
+
+  > removeCurrentForward (MaybeZipList {[3, 2, 1], 7, []})
+  MaybeZipList {[3, 2, 1], 7, []}
+
+-}
+removeCurrentForward : MaybeZipList a -> MaybeZipList a
+removeCurrentForward (MaybeZipList {previous, current, next}) =
+  case next of
+    [] ->
+      MaybeZipList
+        { previous = previous
+        , current = current
+        , next = next
+        }
+
+    [first] ->
+      MaybeZipList
+        { previous = previous
+        , current = Just first
+        , next = []
+        }
+
+    first::rest ->
+      MaybeZipList
+        { previous = previous
+        , current = Just first
+        , next = rest
+        }
+
+
+{-| removeCurrentBack shifts the top of the previous stack into current
+
+examples:
+
+  > removeCurrentBack (MaybeZipList {[3, 2, 1], Just 4, [5, 6, 7]})
+  MaybeZipList {[2, 1], Just 3, [5, 6, 7]}
+
+  > removeCurrentBack (MaybeZipList {[2, 1], Just 3, [5, 6, 7]})
+  MaybeZipList {[1], Just 2, [5, 6, 7]}
+
+  > removeCurrentBack (MaybeZipList {[1], Just 2, [5, 6, 7]})
+  MaybeZipList {[], Just 1, [5, 6, 7]}
+
+  > removeCurrentBack (MaybeZipList {[], Just 1, [5, 6, 7]})
+  MaybeZipList {[], Just 1, [5, 6, 7]}
+
+  > removeCurrentBack (MaybeZipList {[3, 2, 1], Nothing, [5, 6, 7]})
+  MaybeZipList {[2, 1], Just 3, [5, 6, 7]}
+
+  > removeCurrentBack (MaybeZipList {[], Nothing, [5, 6, 7]})
+  MaybeZipList {[], Nothing, [5, 6, 7]}
+
+-}
+removeCurrentBack : MaybeZipList a -> MaybeZipList a
+removeCurrentBack (MaybeZipList {previous, current, next}) =
+  case previous of
+    [] ->
+      MaybeZipList
+        { previous = previous
+        , current = current
+        , next = next
+        }
+
+    [first] ->
+      MaybeZipList
+        { previous = []
+        , current = Just first
+        , next = next
+        }
+
+    first::rest ->
+      MaybeZipList
+        { previous = rest
+        , current = Just first
+        , next = next
+        }
+
+
+{-| toList converts a MaybeZipList into a List
+
+examples:
+
+  > toList (MaybeZipList {[3, 2, 1], 4, [5, 6, 7]})
+  [1, 2, 3, 4, 5, 6, 7]
+
+  > toList (MaybeZipList {[], 1, []})
+  [1]
+
+  > toList (MaybeZipList {[3, 2, 1], Nothing, [5, 6, 7]})
+  [1, 2, 3, 5, 6, 7]
+
+  > toList (MaybeZipList {[], Nothing, []})
+  []
+
+-}
+toList : MaybeZipList a -> List a
+toList (MaybeZipList {previous, current, next}) =
+  let
+      new_next =
+        case current of
+          Just c ->
+            c::next
+
+          Nothing ->
+            next
+  in
+      (List.reverse previous) ++ new_next
+
+
+{-| fromList converts a List into a MaybeZipList
+
+examples:
+
+  > fromList [1, 2, 3, 4, 5]
+  MaybeZipList {[], 1, [2, 3, 4, 5]}
+
+  > fromList []
+  MaybeZipList {[], Nothing, []}
+
+-}
+fromList : List a -> MaybeZipList a
+fromList list =
+  case list of
+    [] ->
+      MaybeZipList
+        { previous = []
+        , current = Nothing
+        , next = []
+        }
+
+    [first] ->
+      MaybeZipList
+        { previous = []
+        , current = Just first
+        , next = []
+        }
+
+    first::rest ->
+      MaybeZipList
+        { previous = []
+        , current = Just first
+        , next = rest
+        }
+
+
+{-| Get the current element from the MaybeZipList
+
+examples:
+
+  > current (MaybeZipList {[3, 2, 1], 4, [5, 6, 7]})
+  4
+
+  > current (MaybeZipList {[], 1, []})
+  1
+
+-}
+current : MaybeZipList a -> Maybe a
+current (MaybeZipList {current}) = current
+
+
+{-| Sets the current value
+
+examples:
+
+  > empty |> setCurrent (Just 5)
+  MaybeZipList {[], Just 5, []}
+
+-}
+setCurrent : Maybe a -> MaybeZipList a -> MaybeZipList a
+setCurrent elem (MaybeZipList {previous, current, next}) =
+  MaybeZipList
+    { previous = previous
+    , current = elem
+    , next = next
+    }
+
+
+{-| Create a new, empty MaybeZipList
+-}
+empty : MaybeZipList a
+empty =
+  MaybeZipList
+    { previous = []
+    , current = Nothing
+    , next = []
+    }
+
+
+{-| Check if MaybeZipList is empty
+
+examples:
+
+  > isEmpty empty
+  True
+
+  > isEmpty (empty |> setCurrent (Just 5))
+  False
+
+-}
+isEmpty : MaybeZipList a -> Bool
+isEmpty (MaybeZipList {previous, current, next}) =
+  List.isEmpty previous && List.isEmpty next && current == Nothing
+
+
+{-| Returns true if current isn't at the beginning
+-}
+canShiftBack : MaybeZipList a -> Bool
+canShiftBack (MaybeZipList {previous}) =
+  not (List.isEmpty previous)
+
+
+{-| Returns true if current isn't at the end
+-}
+canShiftForward : MaybeZipList a -> Bool
+canShiftForward (MaybeZipList {next}) =
+  not (List.isEmpty next)

--- a/src/maybe_zip_list.elm
+++ b/src/maybe_zip_list.elm
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -}
 module MaybeZipList exposing
     (MaybeZipList, shiftBack, shiftForward, toStart, toEnd,
-    insertBefore, insertAfter, removeCurrentForward, removeCurrentBack
+    insertBefore, insertAfter, removeCurrentForward, removeCurrentBack,
     toList, fromList, current, setCurrent, empty, isEmpty,
     canShiftBack, canShiftForward, merge, next, previous,
     deleteNext, deletePrevious)

--- a/src/maybe_zip_list.elm
+++ b/src/maybe_zip_list.elm
@@ -166,16 +166,16 @@ shiftForward (MaybeZipList {previous, current, next}) =
 
 examples:
 
-  toStart (MaybeZipList {[3, 2, 1], Just 4, [5, 6]})
+  > toStart (MaybeZipList {[3, 2, 1], Just 4, [5, 6]})
   MaybeZipList {[], Just 1, [2, 3, 4, 5, 6]}
 
-  toStart (MaybeZipList {[], Just 1, []})
+  > toStart (MaybeZipList {[], Just 1, []})
   MaybeZipList {[], Just 1, []}
 
-  toStart (MaybeZipList {[3, 2, 1], Nothing, [5, 6]})
+  > toStart (MaybeZipList {[3, 2, 1], Nothing, [5, 6]})
   MaybeZipList {[], Just 1, [2, 3, 5, 6]}
 
-  toStart (MaybeZipList {[], Nothing, []})
+  > toStart (MaybeZipList {[], Nothing, []})
   MaybeZipList {[], Nothing, []}
 
 -}
@@ -218,16 +218,16 @@ toStart (MaybeZipList {previous, current, next}) =
 
 examples:
 
-  toEnd (MaybeZipList {[3, 2, 1], 4, [5, 6]})
+  > toEnd (MaybeZipList {[3, 2, 1], 4, [5, 6]})
   MaybeZipList {[5, 4, 3, 2, 1], 6, []}
 
-  toEnd (MaybeZipList {[], 1, []})
+  > toEnd (MaybeZipList {[], 1, []})
   MaybeZipList {[], 1, []}
 
-  toEnd (MaybeZipList {[3, 2, 1], Nothing, [5, 6]})
+  > toEnd (MaybeZipList {[3, 2, 1], Nothing, [5, 6]})
   MaybeZipList {[5, 3, 2, 1], 6, []}
 
-  toEnd (MaybeZipList {[], Nothing, []})
+  > toEnd (MaybeZipList {[], Nothing, []})
   MaybeZipList {[], Nothing, []}
 
 -}

--- a/src/paragraph.elm
+++ b/src/paragraph.elm
@@ -1,0 +1,165 @@
+{-
+Copyright (C) 2017  Riley Trautman
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-}
+module Paragraph exposing
+    (Paragraph, empty, isEmpty, last, lastWithDefault, toStart, toEnd,
+    currentStyle, currentStyleWithDefault, setCurrentStyle,
+    selectPreviousStyle, selectNextStyle,
+    hasPreviousStyle, hasNextStyle,
+    updateCurrentStyle)
+
+{-|
+@docs Paragraph
+@docs empty, isEmpty, last, lastWithDefault, toStart, toEnd
+@docs currentStyle, currentStyleWithDefault setCurrentStyle
+@docs selectPreviousStyle, selectNextStyle
+@docs hasPreviousStyle, hasNextStyle
+@docs updateParagraph
+-}
+
+
+import Styles exposing (Style)
+import Util exposing (fromMaybe, fromMaybeWithDefault)
+import MaybeZipList exposing (..)
+
+
+{-| Paragraph is an alias for Maybe (List Style)
+-}
+type alias Paragraph = MaybeZipList Style
+
+
+{-| empty returns an empty paragraph
+
+examples:
+
+  > empty
+  Nothing
+
+-}
+empty : Paragraph
+empty = MaybeZipList.empty
+
+
+{-| return whether or not paragraph is empty
+
+examples:
+
+  > isEmpty (ZipList.fromList [Style.empty])
+  False
+
+  > isEmpty (ZipList.fromList [])
+  True
+
+-}
+isEmpty : Paragraph -> Bool
+isEmpty = MaybeZipList.isEmpty
+
+
+{-| get the last style from the paragraph
+
+examples:
+
+  > last (ZipList.fromList [Style.empty])
+  Just (Style.empty)
+
+  > last (ZipList.fromList [])
+  Nothing
+
+-}
+last : Paragraph -> Maybe Style
+last = MaybeZipList.current << MaybeZipList.toEnd
+
+
+{-| get the last style from the paragraph
+
+if the paragraph is Nothing, return the default
+
+examples:
+
+  > lastWithDefault defaultStyle (ZipList.fromList [Style.empty])
+  Style.empty
+
+  > lastWithDefault defaultStyle (ZipList.fromList [])
+  defaultStyle
+
+-}
+lastWithDefault : Style -> Paragraph -> Style
+lastWithDefault = Util.fromMaybeWithDefault (last)
+
+
+{-| Shift currentStyle to Start
+-}
+toStart : Paragraph -> Paragraph
+toStart = MaybeZipList.toStart
+
+
+{-| Shift currentStyle to End
+-}
+toEnd : Paragraph -> Paragraph
+toEnd = MaybeZipList.toStart
+
+
+{-| get the current style
+-}
+currentStyle : Paragraph -> Maybe Style
+currentStyle = MaybeZipList.current
+
+
+{-| get the current style with a default fallback
+-}
+currentStyleWithDefault : Style -> Paragraph -> Style
+currentStyleWithDefault = Util.fromMaybeWithDefault (currentStyle)
+
+
+{-| set the current style
+-}
+setCurrentStyle : Style -> Paragraph -> Paragraph
+setCurrentStyle style = MaybeZipList.setCurrent (Just style)
+
+
+{-| shift to previous style
+-}
+selectPreviousStyle : Paragraph -> Paragraph
+selectPreviousStyle = MaybeZipList.shiftBack
+
+
+{-| shift to next style
+-}
+selectNextStyle : Paragraph -> Paragraph
+selectNextStyle = MaybeZipList.shiftForward
+
+
+{-| checks if previous style exists
+-}
+hasPreviousStyle : Paragraph -> Bool
+hasPreviousStyle = MaybeZipList.canShiftBack
+
+
+{-| checks if next style exists
+-}
+hasNextStyle : Paragraph -> Bool
+hasNextStyle = MaybeZipList.canShiftForward
+
+
+{-| Applies update function to current style
+-}
+updateCurrentStyle : (Style -> Style) -> Paragraph -> Paragraph
+updateCurrentStyle fn paragraph =
+  paragraph
+    |> currentStyle
+    |> Util.fromMaybeWithDefault identity Style.empty
+    |> fn
+    |> flip (setCurrentStyle) paragraph

--- a/src/paragraph.elm
+++ b/src/paragraph.elm
@@ -19,7 +19,10 @@ module Paragraph exposing
     currentStyle, currentStyleWithDefault, setCurrentStyle,
     selectPreviousStyle, selectNextStyle,
     hasPreviousStyle, hasNextStyle,
-    updateCurrentStyle)
+    updateCurrentStyle, merge,
+    removeCurrentStyle, nextStyles, previousStyles,
+    clearNextStyles, clearPreviousStyles,
+    toList, fromList, insertBefore, insertAfter)
 
 {-|
 @docs Paragraph
@@ -28,6 +31,10 @@ module Paragraph exposing
 @docs selectPreviousStyle, selectNextStyle
 @docs hasPreviousStyle, hasNextStyle
 @docs updateParagraph
+@docs merge
+@docs nextStyles, previousStyles, clearNextStyles, clearPreviousStyles
+@docs toList, fromList
+@docs insertBefore, insertAfter
 -}
 
 
@@ -163,3 +170,63 @@ updateCurrentStyle fn paragraph =
     |> Util.fromMaybeWithDefault identity Style.empty
     |> fn
     |> flip (setCurrentStyle) paragraph
+
+
+{-| Merge paragraphs
+-}
+merge : Paragraph -> Paragraph -> Paragraph
+merge p1 p2 = MaybeZipList.merge (toEnd p1) p2
+
+
+{-| Remove the current style from the paragraph. Move previous style to current
+-}
+removeCurrentStyle : Paragraph -> Paragraph
+removeCurrentStyle = MaybeZipList.removeCurrentBack
+
+
+{-| Get the styles after current
+-}
+nextStyles : Paragraph -> List Style
+nextStyles = MaybeZipList.next
+
+
+{-| Get the styles before current
+-}
+previousStyles : Paragraph -> List Style
+previousStyles = MaybeZipList.previous
+
+
+{-| Remove styles after current
+-}
+clearNextStyles : Paragraph -> Paragraph
+clearNextStyles = MaybeZipList.deleteNext
+
+
+{-| Remove styles before current
+-}
+clearPreviousStyles : Paragraph -> Paragraph
+clearPreviousStyles = MaybeZipList.deletePrevious
+
+
+{-| Make a paragraph from a list
+-}
+fromList : List Style -> Paragraph
+fromList = MaybeZipList.fromList
+
+
+{-| Make a list from a Paragraph
+-}
+toList : Paragraph -> List Style
+toList = MaybeZipList.toList
+
+
+{-| Insert a style before the current style and select it
+-}
+insertBefore : Maybe Style -> Paragraph -> Paragraph
+insertBefore = MaybeZipList.insertBefore
+
+
+{-| Insert a style after the current style and select it
+-}
+insertAfter : Maybe Style -> Paragraph -> Paragraph
+insertAfter = MaybeZipList.insertAfter

--- a/src/paragraph.elm
+++ b/src/paragraph.elm
@@ -64,7 +64,7 @@ empty = MaybeZipList.empty
 
 examples:
 
-  > isEmpty (ZipList.fromList [Style.empty])
+  > isEmpty (ZipList.fromList [Styles.empty])
   False
 
   > isEmpty (ZipList.fromList [])
@@ -79,8 +79,8 @@ isEmpty = MaybeZipList.isEmpty
 
 examples:
 
-  > last (ZipList.fromList [Style.empty])
-  Just (Style.empty)
+  > last (ZipList.fromList [Styles.empty])
+  Just (Styles.empty)
 
   > last (ZipList.fromList [])
   Nothing
@@ -96,15 +96,18 @@ if the paragraph is Nothing, return the default
 
 examples:
 
-  > lastWithDefault defaultStyle (ZipList.fromList [Style.empty])
-  Style.empty
+  > lastWithDefault defaultStyle (ZipList.fromList [Styles.empty])
+  Styles.empty
 
   > lastWithDefault defaultStyle (ZipList.fromList [])
   defaultStyle
 
 -}
 lastWithDefault : Style -> Paragraph -> Style
-lastWithDefault = Util.fromMaybeWithDefault (last)
+lastWithDefault style paragraph =
+  paragraph
+    |> last
+    |> Util.fromMaybeWithDefault identity style
 
 
 {-| Shift currentStyle to Start
@@ -128,7 +131,10 @@ currentStyle = MaybeZipList.current
 {-| get the current style with a default fallback
 -}
 currentStyleWithDefault : Style -> Paragraph -> Style
-currentStyleWithDefault = Util.fromMaybeWithDefault (currentStyle)
+currentStyleWithDefault style paragraph =
+  paragraph
+    |> currentStyle
+    |> Util.fromMaybeWithDefault identity style
 
 
 {-| set the current style
@@ -167,7 +173,7 @@ updateCurrentStyle : (Style -> Style) -> Paragraph -> Paragraph
 updateCurrentStyle fn paragraph =
   paragraph
     |> currentStyle
-    |> Util.fromMaybeWithDefault identity Style.empty
+    |> Util.fromMaybeWithDefault identity Styles.empty
     |> fn
     |> flip (setCurrentStyle) paragraph
 

--- a/src/styles.elm
+++ b/src/styles.elm
@@ -18,7 +18,7 @@ module Styles exposing
     (Style, setLinkHref, setText, appendText, toggleCode, toggleImage,
     toggleText, toggleStrike, toggleUnderline, toggleItalic, toggleBold,
     toggleHeading, toggleLink, serializeToString, renderStyle, isEmpty,
-    getText, setMouseoverText)
+    getText, setMouseoverText, defaultStyle)
 
 {-|
 @docs Style
@@ -26,7 +26,7 @@ module Styles exposing
 @docs setLinkHref, setText, appendText, toggleCode, toggleImage, toggleStrike
 @docs toggleUnderline, toggleItalic, toggleBold, toggleHeading, toggleLink
 @docs serializeToString, renderStyle, isEmpty, getText, setMouseoverText
-@docs toggleText
+@docs toggleText, defaultStyle
 -}
 
 import Html exposing (..)
@@ -70,6 +70,8 @@ defaultAttributes =
   }
 
 
+{-| Initialize style with sane defaults
+-}
 defaultStyle : Style
 defaultStyle =
   Style

--- a/src/styles.elm
+++ b/src/styles.elm
@@ -70,6 +70,14 @@ defaultAttributes =
   }
 
 
+defaultStyle : Style
+defaultStyle =
+  Style
+    { link_wrapper = Only (Text defaultAttributes)
+    , text = ""
+    }
+
+
 {-| Set the URL of a link in a content chain
 
 examples:

--- a/src/styles.elm
+++ b/src/styles.elm
@@ -15,17 +15,17 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -}
 module Styles exposing
-    (Style, setLinkHref, setText, appendText, toggleCode, toggleImage,
-    toggleText, toggleStrike, toggleUnderline, toggleItalic, toggleBold,
-    toggleHeading, toggleLink, serializeToString, renderStyle, isEmpty,
-    getText, setMouseoverText, empty)
+    (Style, setLinkHref, setText, updateText, appendText, toggleCode,
+    toggleImage, toggleText, toggleStrike, toggleUnderline, toggleItalic,
+    toggleBold, toggleHeading, toggleLink, serializeToString, render,
+    isEmpty, getText, setMouseoverText, empty)
 
 {-|
 @docs Style
 
 @docs setLinkHref, setText, appendText, toggleCode, toggleImage, toggleStrike
 @docs toggleUnderline, toggleItalic, toggleBold, toggleHeading, toggleLink
-@docs serializeToString, renderStyle, isEmpty, getText, setMouseoverText
+@docs serializeToString, render, isEmpty, getText, setMouseoverText
 @docs toggleText, empty
 -}
 
@@ -109,6 +109,22 @@ setText text (Style { link_wrapper }) =
   Style
     { link_wrapper = link_wrapper
     , text = text
+    }
+
+
+{-| Apply a function to modify the style's text
+
+examples :
+
+  > updateText (dropRight 1) (Style { _, "hello world" })
+  Style { _, "hello worl" }
+
+-}
+updateText : (String -> String) -> Style -> Style
+updateText fn (Style { link_wrapper, text }) =
+  Style
+    { link_wrapper = link_wrapper
+    , text = fn text
     }
 
 
@@ -557,8 +573,8 @@ serializeToString (Style { link_wrapper, text }) =
       "Style { Link " ++ href ++ " (" ++ (serializeStyleTypeToString style_type) ++ "), " ++ text ++ " }"
 
 
-renderStyleAttributes : StyleAttributes -> String -> Html msg
-renderStyleAttributes attributes str =
+renderAttributes : StyleAttributes -> String -> Html msg
+renderAttributes attributes str =
   let
       heading =
         if attributes.heading then
@@ -592,11 +608,11 @@ renderStyleAttributes attributes str =
   in
       strike
 
-renderStyleType : StyleType -> String -> Html msg
-renderStyleType style_type string =
+renderType : StyleType -> String -> Html msg
+renderType style_type string =
   case style_type of
     Text attributes ->
-      renderStyleAttributes attributes string
+      renderAttributes attributes string
 
     Image mouseover ->
       case mouseover of
@@ -618,10 +634,10 @@ of a helper function
 
 examples:
 
-  > renderStyle (Style { Only (Text {False, True, False, False, False}), "hello world" })
+  > render (Style { Only (Text {False, True, False, False, False}), "hello world" })
   b [] [ text "hello world" ]
 
-  > renderStyle (Style { Link "https://google.com" (Text {True, True, True, True, True}), "hello world" })
+  > render (Style { Link "https://google.com" (Text {True, True, True, True, True}), "hello world" })
   a [ href "https://google.com" ]
     [ h3 []
         [ b []
@@ -635,11 +651,11 @@ examples:
         ]
     ]
 -}
-renderStyle : Style -> Html msg
-renderStyle (Style { link_wrapper, text }) =
+render : Style -> Html msg
+render (Style { link_wrapper, text }) =
   case link_wrapper of
     Only style_type ->
-      renderStyleType style_type text
+      renderType style_type text
 
     Link url style_type ->
-      a [ href url ] [ renderStyleType style_type text ]
+      a [ href url ] [ renderType style_type text ]

--- a/src/styles.elm
+++ b/src/styles.elm
@@ -23,8 +23,9 @@ module Styles exposing
 {-|
 @docs Style
 
-@docs setLinkHref, setText, appendText, toggleCode, toggleImage, toggleStrike
-@docs toggleUnderline, toggleItalic, toggleBold, toggleHeading, toggleLink
+@docs setLinkHref, setText, updateText, appendText
+@docs toggleCode, toggleImage, toggleStrike, toggleUnderline
+@docs toggleItalic, toggleBold, toggleHeading, toggleLink
 @docs serializeToString, render, isEmpty, getText, setMouseoverText
 @docs toggleText, empty
 -}

--- a/src/styles.elm
+++ b/src/styles.elm
@@ -18,7 +18,7 @@ module Styles exposing
     (Style, setLinkHref, setText, appendText, toggleCode, toggleImage,
     toggleText, toggleStrike, toggleUnderline, toggleItalic, toggleBold,
     toggleHeading, toggleLink, serializeToString, renderStyle, isEmpty,
-    getText, setMouseoverText, defaultStyle)
+    getText, setMouseoverText, empty)
 
 {-|
 @docs Style
@@ -26,7 +26,7 @@ module Styles exposing
 @docs setLinkHref, setText, appendText, toggleCode, toggleImage, toggleStrike
 @docs toggleUnderline, toggleItalic, toggleBold, toggleHeading, toggleLink
 @docs serializeToString, renderStyle, isEmpty, getText, setMouseoverText
-@docs toggleText, defaultStyle
+@docs toggleText, empty
 -}
 
 import Html exposing (..)
@@ -72,8 +72,8 @@ defaultAttributes =
 
 {-| Initialize style with sane defaults
 -}
-defaultStyle : Style
-defaultStyle =
+empty : Style
+empty =
   Style
     { link_wrapper = Only (Text defaultAttributes)
     , text = ""

--- a/src/styles.elm
+++ b/src/styles.elm
@@ -18,7 +18,7 @@ module Styles exposing
     (Style, setLinkHref, setText, updateText, appendText, toggleCode,
     toggleImage, toggleText, toggleStrike, toggleUnderline, toggleItalic,
     toggleBold, toggleHeading, toggleLink, serializeToString, render,
-    isEmpty, getText, setMouseoverText, empty)
+    isEmpty, getText, setMouseoverText, empty, toMaybe)
 
 {-|
 @docs Style
@@ -27,7 +27,7 @@ module Styles exposing
 @docs toggleCode, toggleImage, toggleStrike, toggleUnderline
 @docs toggleItalic, toggleBold, toggleHeading, toggleLink
 @docs serializeToString, render, isEmpty, getText, setMouseoverText
-@docs toggleText, empty
+@docs toggleText, empty, toMaybe
 -}
 
 import Html exposing (..)
@@ -660,3 +660,14 @@ render (Style { link_wrapper, text }) =
 
     Link url style_type ->
       a [ href url ] [ renderType style_type text ]
+
+
+{-| Convert empty styles to Nothing, otherwise return Just Style
+-}
+toMaybe : Style -> Maybe Style
+toMaybe style =
+  if isEmpty style then
+    Nothing
+
+  else
+    Just style

--- a/src/util.elm
+++ b/src/util.elm
@@ -1,0 +1,88 @@
+{-
+Copyright (C) 2017  Riley Trautman
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-}
+module Util exposing
+    (fromMaybe, fromMaybeWithDefault, fromTwoMaybes, fromTwoMaybesWithDefault)
+
+{-| fromMaybe allows the chaining of uncertain operations
+
+examples:
+
+  > [1, 2, 3] |> List.tail |> fromMaybe (List.head)
+  Just 2
+
+  > [1] |> List.tail |> fromMaybe (List.head)
+  Nothing
+
+-}
+fromMaybe : (a -> Maybe b) -> Maybe a -> Maybe b
+fromMaybe fn = fromMaybeWithDefault fn Nothing
+
+
+{-| fromMaybeWithDefault allows a value to be resolved from uncertain operations
+
+
+examples:
+
+  > [1, 2, 3] |> List.tail |> fromMaybeWithDefault (List.head) 0
+  2
+
+  > [1] |> List.tail |> fromMaybeWithDefault (List.head) 0
+  0
+
+-}
+fromMaybeWithDefault : (a -> b) -> b -> Maybe a -> b
+fromMaybeWithDefault fn default maybe_item =
+  case maybe_item of
+    Just item ->
+      fn item
+
+    Nothing ->
+      default
+
+
+{-| fromTwoMaybes allows composition of multiple maybe types
+
+examples:
+
+  > fromTwoMaybes (identity) (Just "one") (Just "two")
+  Just ("one", "two")
+
+  > fromTwoMaybes (identity) (Just "one") (Nothing)
+  Nothing
+
+-}
+fromTwoMaybes : (a -> b -> Maybe c) -> Maybe a -> Maybe b -> Maybe c
+fromTwoMaybes fn = fromTwoMaybesWithDefault fn Nothing
+
+
+{-| fromTwoMaybesWithDefault allows a value to be resolved from two uncertain values
+
+examples:
+
+  > fromTwoMaybesWithDefault (curry identity) (0, "four") (Just 1) (Just "two")
+  (1, "two")
+
+  > fromTwoMaybesWithDefault (curry identity) (0, "four") (Just 1) (Nothing)
+  (0, "four")
+
+-}
+fromTwoMaybesWithDefault : (a -> b -> c) -> c -> Maybe a -> Maybe b -> c
+fromTwoMaybesWithDefault fn default maybe_one maybe_two =
+  fromMaybeWithDefault
+    (\x -> fromMaybeWithDefault (fn x) default maybe_two)
+    default
+    maybe_one

--- a/src/zip_list.elm
+++ b/src/zip_list.elm
@@ -18,7 +18,7 @@ module ZipList exposing
     (ZipList, shiftBack, shiftForward, toStart, toEnd,
     insertBefore, insertAfter, removeCurrentForward, removeCurrentBack
     toList, fromList, current, setCurrent, init,
-    canShiftBack, canShiftForward)
+    canShiftBack, canShiftForward, merge)
 
 {-|
 @docs ZipList
@@ -29,6 +29,7 @@ module ZipList exposing
 @docs current, setcurrent
 @docs init
 @docs canShiftBack, canShiftForward
+@docs merge
 -}
 
 
@@ -188,3 +189,13 @@ canShiftBack (ZipList {maybe_zip_list}) =
 canShiftForward : MaybeZipList a -> Bool
 canShiftForward (ZipList {maybe_zip_list}) =
   MaybeZipList.canShiftForward maybe_zip_list
+
+
+{-| Merges current ZipList with another
+-}
+merge : ZipList a -> ZipList b -> ZipList c
+merge (ZipList {default_value, maybe_zip_list}) (ZipList two) =
+  ZipList
+    { maybe_zip_list = MaybeZipList.merge maybe_zip_list two.maybe_zip_list
+    , default_value = default_value
+    }

--- a/src/zip_list.elm
+++ b/src/zip_list.elm
@@ -1,0 +1,190 @@
+{-
+Copyright (C) 2017  Riley Trautman
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-}
+module ZipList exposing
+    (ZipList, shiftBack, shiftForward, toStart, toEnd,
+    insertBefore, insertAfter, removeCurrentForward, removeCurrentBack
+    toList, fromList, current, setCurrent, init,
+    canShiftBack, canShiftForward)
+
+{-|
+@docs ZipList
+@docs shiftForward, shiftBack, toStart, toEnd
+@docs insertBefore, insertAfter
+@docs removeCurrentForward, removeCurrentBack
+@docs toList, fromList
+@docs current, setcurrent
+@docs init
+@docs canShiftBack, canShiftForward
+-}
+
+
+import MaybeZipList exposing (..)
+
+
+{-| ZipLists are useful for ensuring a list can never be empty
+
+This ZipList is a wrapper around MaybeZipList, and includes a default value
+-}
+type ZipList a =
+  ZipList
+    { maybe_zip_list : MaybeZipList a
+    , default_value : a
+    }
+
+
+{- shiftBack cycles through the ZipList towards the beginning
+-}
+shiftBack : ZipList a -> ZipList a
+shiftBack (ZipList {default_value, maybe_zip_list}) =
+  ZipList
+    { maybe_zip_list = MaybeZipList.shiftBack maybe_zip_list
+    , default_value = default_value
+    }
+
+
+{- shiftForward cycles through the ZipList towards the end
+-}
+shiftForward : ZipList a -> ZipList a
+shiftForward (ZipList {default_value, maybe_zip_list}) =
+  ZipList
+    { maybe_zip_list = MaybeZipList.shiftForward maybe_zip_list
+    , default_value = default_value
+    }
+
+
+{-| toStart resets the ZipList to the beginning
+-}
+toStart : ZipList a -> ZipList a
+toStart (ZipList {default_value, maybe_zip_list}) =
+  ZipList
+    { maybe_zip_list = MaybeZipList.toStart maybe_zip_list
+    , default_value = default_value
+    }
+
+
+{-| toEnd resets the ZipList to the beginning
+-}
+toEnd : ZipList a -> ZipList a
+toEnd (ZipList {default_value, maybe_zip_list}) =
+  ZipList
+    { maybe_zip_list = MaybeZipList.toEnd maybe_zip_list
+    , default_value = default_value
+    }
+
+
+{-| insertBefore puts a new item in the ZipList before the current item
+-}
+insertBefore : a -> ZipList a -> ZipList a
+insertBefore elem (ZipList {default_value, maybe_zip_list}) =
+  ZipList
+    { maybe_zip_list = MaybeZipList.insertBefore (Just elem) maybe_zip_list
+    , default_value = default_value
+    }
+
+
+{-| insertAfter puts a new item in the ZipList before the current item
+-}
+insertAfter : a -> ZipList a -> ZipList a
+insertAfter elem (ZipList {previous, current, next}) =
+  ZipList
+    { maybe_zip_list = MaybeZipList.insertAfter (Just elem) maybe_zip_list
+    , default_value = default_value
+    }
+
+
+
+{-| removeCurrentForward shifts the top of the next stack into current
+-}
+removeCurrentForward : ZipList a -> ZipList a
+removeCurrentForward (ZipList {default_value, maybe_zip_list}) =
+  ZipList
+    { maybe_zip_list = MaybeZipList.removeCurrentForward maybe_zip_list
+    , default_value = default_value
+    }
+
+
+{-| removeCurrentBack shifts the top of the previous stack into current
+-}
+removeCurrentBack : ZipList a -> ZipList a
+removeCurrentBack (ZipList {default_value, maybe_zip_list}) =
+  ZipList
+    { maybe_zip_list = MaybeZipList.removeCurrentBack maybe_zip_list
+    , default_value = default_value
+    }
+
+
+{-| toList converts a ZipList into a List
+-}
+toList : ZipList a -> List a
+toList (ZipList {maybe_zip_list}) =
+  MaybeZipList.toList maybe_zip_list
+
+
+{-| fromList converts a List into a ZipList
+-}
+fromList : a -> List a -> ZipList a
+fromList default list =
+  ZipList
+    { maybe_zip_list = MaybeZipList.fromList list
+    , default_value = default
+    }
+
+
+{-| Get the current element from the ZipList
+-}
+current : ZipList a -> a
+current (ZipList {default_value, maybe_zip_list}) =
+  case MaybeZipList.current maybe_zip_list of
+    Just c ->
+      c
+
+    Nothing ->
+      default_value
+
+
+{-| Sets the current value
+-}
+setCurrent : a -> ZipList a -> ZipList a
+setCurrent elem (ZipList {default_value, maybe_zip_list}) =
+  ZipList
+    { maybe_zip_list = MaybeZipList.setCurrent (Just elem) maybe_zip_list
+    , default_value = default_value
+    }
+
+
+{-| Create a new ZipList with one element
+-}
+init : a -> ZipList a
+init default =
+  ZipList
+    { maybe_zip_list = MaybeZipList.fromList [default]
+    , default_value = default
+    }
+
+
+{-| Returns true if current isn't at the beginning
+-}
+canShiftBack : ZipList a -> Bool
+canShiftBack (ZipList {maybe_zip_list}) =
+  MaybeZipList.canShiftBack maybe_zip_list
+
+
+{-| Returns true if current isn't at the end
+-}
+canShiftForward : MaybeZipList a -> Bool
+canShiftForward (ZipList {maybe_zip_list}) =
+  MaybeZipList.canShiftForward maybe_zip_list

--- a/src/zip_list.elm
+++ b/src/zip_list.elm
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -}
 module ZipList exposing
     (ZipList, shiftBack, shiftForward, toStart, toEnd,
-    insertBefore, insertAfter, removeCurrentForward, removeCurrentBack
+    insertBefore, insertAfter, removeCurrentForward, removeCurrentBack,
     toList, fromList, current, setCurrent, init,
     canShiftBack, canShiftForward, merge)
 
@@ -100,7 +100,7 @@ insertBefore elem (ZipList {default_value, maybe_zip_list}) =
 {-| insertAfter puts a new item in the ZipList before the current item
 -}
 insertAfter : a -> ZipList a -> ZipList a
-insertAfter elem (ZipList {previous, current, next}) =
+insertAfter elem (ZipList {default_value, maybe_zip_list}) =
   ZipList
     { maybe_zip_list = MaybeZipList.insertAfter (Just elem) maybe_zip_list
     , default_value = default_value
@@ -186,14 +186,14 @@ canShiftBack (ZipList {maybe_zip_list}) =
 
 {-| Returns true if current isn't at the end
 -}
-canShiftForward : MaybeZipList a -> Bool
+canShiftForward : ZipList a -> Bool
 canShiftForward (ZipList {maybe_zip_list}) =
   MaybeZipList.canShiftForward maybe_zip_list
 
 
 {-| Merges current ZipList with another
 -}
-merge : ZipList a -> ZipList b -> ZipList c
+merge : ZipList a -> ZipList a -> ZipList a
 merge (ZipList {default_value, maybe_zip_list}) (ZipList two) =
   ZipList
     { maybe_zip_list = MaybeZipList.merge maybe_zip_list two.maybe_zip_list

--- a/src/zip_list.elm
+++ b/src/zip_list.elm
@@ -18,7 +18,8 @@ module ZipList exposing
     (ZipList, shiftBack, shiftForward, toStart, toEnd,
     insertBefore, insertAfter, removeCurrentForward, removeCurrentBack,
     toList, fromList, current, setCurrent, init,
-    canShiftBack, canShiftForward, merge)
+    canShiftBack, canShiftForward, merge,
+    serializeToString)
 
 {-|
 @docs ZipList
@@ -30,6 +31,7 @@ module ZipList exposing
 @docs init
 @docs canShiftBack, canShiftForward
 @docs merge
+@docs serializeToString
 -}
 
 
@@ -199,3 +201,23 @@ merge (ZipList {default_value, maybe_zip_list}) (ZipList two) =
     { maybe_zip_list = MaybeZipList.merge maybe_zip_list two.maybe_zip_list
     , default_value = default_value
     }
+
+
+{-| Serialize the current item to String
+-}
+serializeToString : (a -> String) -> ZipList a -> String
+serializeToString fn (ZipList {default_value, maybe_zip_list}) =
+  let
+      string_default_value : String
+      string_default_value =
+        "default_value: " ++ (fn default_value)
+
+      string_maybe_zip_list : String
+      string_maybe_zip_list =
+        "maybe_zip_list: ("
+          ++ (MaybeZipList.serializeToString fn maybe_zip_list)
+          ++ ")"
+  in
+      "ZipList {"
+        ++ string_default_value ++ ", "
+        ++ string_maybe_zip_list ++ "}"


### PR DESCRIPTION
Project rewritten using ZipLists as the collection datatype for holding styles and paragraphs in order to [Make Impossible States Impossible(tm)](https://www.youtube.com/watch?v=IcgmSRJHu_8).

Two forms of ZipLists have been implemented for this project.
The `Content` type is now an alias for a normal `ZipList Paragraph`, while the `Paragraph` type is an alias for a `MaybeZipList Style`. `MaybeZipLists` allow the one element that exists to be `Nothing`, but disallow more than one Nothing in the collection. The `ZipList a` type provided is a wrapper around the `MaybeZipList a` type that maintains knowledge of a default value to return in the event that the `current` value is `Nothing` (this should never happen).

It is a bit ironic that I'm relying on a "(this should never happen)" in a datatype I designed to make impossible states impossible, but I can rewrite that another day to not be a wrapper.

What Works:
 - Typing
 - Left and Right Arrow Keys
 - New Paragraphs

What doesn't work:
 - Up and Down Arrow Keys